### PR TITLE
Update jQuery to latest version of v1.x

### DIFF
--- a/_includes/js_files.html
+++ b/_includes/js_files.html
@@ -1,7 +1,7 @@
 <script>
   var baseurl = '{{ site.baseurl }}'
 </script>
-<script src="https://code.jquery.com/jquery-1.10.2.min.js"></script>
+<script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
 <script src="{{ "/js/bootstrap.min.js" | prepend: site.baseurl }} "></script>
 <script src="{{ "/js/typeahead.bundle.min.js" | prepend: site.baseurl }} "></script>
 


### PR DESCRIPTION
Update jQuery to latest version of v1.x

I ideally wanted to update to jQuery 3.x but it caused issues with typeahead JS. I need to look into that....