### PR TITLE
add .gitattributes for showing ‘Ruby’ instead ‘CSS’ on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.html linguist-vendored
+*.css linguist-vendored
+*.scss linguist-vendored
+*.js linguist-vendored


### PR DESCRIPTION
it's not related with source code but if you mind with GitHub badge,.

from:
![image](https://user-images.githubusercontent.com/16218269/61723367-f4845380-ada6-11e9-915f-eb274561ec51.png)

to:
![image](https://user-images.githubusercontent.com/16218269/61723411-0e259b00-ada7-11e9-8788-c7bca58dfdc6.png)
