### PR TITLE
Updated asset/pages and scss files

### DIFF
--- a/_docs/customization.md
+++ b/_docs/customization.md
@@ -3,7 +3,7 @@ title: Customization
 permalink: /docs/customization/
 ---
 
-This template uses [bootstrap-sass](https://github.com/twbs/bootstrap-sass) along with [bootwatch themes](https://bootswatch.com/).
+This template uses [bootstrap-sass](https://github.com/twbs/bootstrap-sass) along with [bootwatch themes](https://bootswatch.com/3).
 You can create your own theme by writing your own `sass` files.
 
 Create a new a theme folder like `_sass/bootwatch/custom` and set your `bootwatch` variables in `_config.yml` to `custom`:

--- a/_docs/index.md
+++ b/_docs/index.md
@@ -12,7 +12,7 @@ The good thing about coupling your documentation with the source repo is, whenev
 
 1. Just [download the source](https://github.com/aksakalli/jekyll-doc-theme/archive/gh-pages.zip) into your repo under `docs` folder.
 2. Edit site settings in  `_config.yml` file according to your project. !!! `baseurl` should be your website's relative URI like `/my-proj` !!!
-3. Replace `favicon.ico` and `img/logonav.png` with your own logo.
+3. Replace `favicon.ico` and `assets/img/logonav.png` with your own logo.
 
 ## Writing content
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,8 +3,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="{{ "/css/main.css" | relative_url }}">
-    <link rel="stylesheet" href="{{ "/css/font-awesome.min.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}">
+    <link rel="stylesheet" href="{{ "/assets/css/font-awesome.min.css" | relative_url }}">
 
     <link rel="shortcut icon" href="{{ "/favicon.ico?1" | relative_url }}">
     {% seo %}

--- a/_includes/js_files.html
+++ b/_includes/js_files.html
@@ -2,7 +2,7 @@
   var baseurl = '{{ site.baseurl }}'
 </script>
 <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
-<script src="{{ "/js/bootstrap.min.js" | relative_url }} "></script>
-<script src="{{ "/js/typeahead.bundle.min.js" | relative_url }} "></script>
+<script src="{{ "/assets/js/bootstrap.min.js" | relative_url }} "></script>
+<script src="{{ "/assets/js/typeahead.bundle.min.js" | relative_url }} "></script>
 
-<script src="{{ "/js/main.js" | relative_url }} "></script>
+<script src="{{ "/assets/js/main.js" | relative_url }} "></script>

--- a/_includes/topnav.html
+++ b/_includes/topnav.html
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
       </button>
             <a class="navbar-brand" href="{{ site.baseurl }}/">
-                <span><img src="{{site.baseurl}}/img/logonav.png" alt="Logo"></span> {{ site.title }}
+                <span><img src="{{ "/assets/img/logonav.png" | relative_url }}" alt="Logo"></span> {{ site.title }}
             </a>
         </div>
         <div id="navbar" class="collapse navbar-collapse">

--- a/_sass/_jekyll-doc-theme.scss
+++ b/_sass/_jekyll-doc-theme.scss
@@ -1,0 +1,64 @@
+
+html {
+    position: relative;
+    min-height: 100%;
+  }
+  body {
+    padding-top: $navbar-height + $navbar-margin-bottom;
+    margin-bottom: 46px;
+  }
+  
+  .navbar-brand{
+    img{
+      margin: -$navbar-padding-vertical 0;
+      height: $navbar-height;
+      padding: 10px 0;
+    }
+  }
+  
+  
+  .header-container {
+    background-color: black;
+    background: url('../img/bg.jpg') no-repeat 50% 0;
+    color: #fff;
+  
+    h1 {
+      color: #fff;
+    }
+    // background-attachment: fixed;
+    background-size: cover;
+    background-position: center 36%;
+    margin-top: -37px;
+  }
+  .navbar-container {
+    font-size: 16px;
+  }
+  .page-content {
+    padding-bottom: 20px;
+  }
+  .footer {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+    height: 46px;
+    padding-top: 10px;
+    background-color: $gray-lighter;
+    color: $gray-dark;
+  }
+  
+  .post-list-container {
+    li a.active {
+      font-weight: bold;
+    }
+  }
+  *[id]:before {
+    display: block;
+    content: " ";
+    margin-top: -75px;
+    height: 75px;
+    visibility: hidden;
+  }
+  .navbar-form .has-feedback .form-control-feedback{
+    top:10px
+  }
+  

--- a/_sass/_jekyll-doc-theme.scss
+++ b/_sass/_jekyll-doc-theme.scss
@@ -39,8 +39,7 @@ html {
   .footer {
     position: absolute;
     bottom: 0;
-    width: 100%;
-    height: 46px;
+    width: 100%;    
     padding-top: 10px;
     background-color: $gray-lighter;
     color: $gray-dark;

--- a/_sass/_typeahead.scss
+++ b/_sass/_typeahead.scss
@@ -19,6 +19,8 @@ span.twitter-typeahead {
     }
     // Added to suggestion elements.
     .tt-suggestion {
+        color: $navbar-default-color;
+
         // mimic .dropdown-menu > li > a
         padding: 3px 20px;
         line-height: $line-height-base;

--- a/assets/404.html
+++ b/assets/404.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: 404.html
 ---
 
 <div class="container text-center">

--- a/assets/allposts.html
+++ b/assets/allposts.html
@@ -2,6 +2,7 @@
 title: Blog
 layout: default
 sectionid: blog
+permalink: allposts.html
 ---
 
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -17,6 +17,5 @@
   {% endif %}
 
   "syntax-highlighting",
-  "typeahead",
   "jekyll-doc-theme"
 ;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,8 +5,6 @@
 
 // Import partials from `sass_dir` (defaults to `_sass`)
 
-
-
 @import
   {% if site.bootwatch %}
     "bootswatch/{{site.bootwatch | downcase}}/variables",
@@ -19,68 +17,6 @@
   {% endif %}
 
   "syntax-highlighting",
-  "typeahead"
+  "typeahead",
+  "jekyll-doc-theme"
 ;
-
-html {
-  position: relative;
-  min-height: 100%;
-}
-body {
-  padding-top: $navbar-height + $navbar-margin-bottom;
-  margin-bottom: 46px;
-}
-
-.navbar-brand{
-  img{
-    margin: -$navbar-padding-vertical 0;
-    height: $navbar-height;
-    padding: 10px 0;
-  }
-}
-
-
-.header-container {
-  background-color: black;
-  background: url('../img/bg.jpg') no-repeat 50% 0;
-  color: #fff;
-
-  h1 {
-    color: #fff;
-  }
-  // background-attachment: fixed;
-  background-size: cover;
-  background-position: center 36%;
-  margin-top: -37px;
-}
-.navbar-container {
-  font-size: 16px;
-}
-.page-content {
-  padding-bottom: 20px;
-}
-.footer {
-  position: absolute;
-  bottom: 0;
-  width: 100%;
-  height: 46px;
-  padding-top: 10px;
-  background-color: $gray-lighter;
-  color: $gray-dark;
-}
-
-.post-list-container {
-  li a.active {
-    font-weight: bold;
-  }
-}
-*[id]:before {
-  display: block;
-  content: " ";
-  margin-top: -75px;
-  height: 75px;
-  visibility: hidden;
-}
-.navbar-form .has-feedback .form-control-feedback{
-  top:10px
-}

--- a/assets/search.json
+++ b/assets/search.json
@@ -1,4 +1,5 @@
 ---
+permalink: search.json
 ---
 [
 {% for section in site.data.docs %}

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@ layout: default
               free</strong>.</p>
         </div>
         <div class="col-md-6 text-center">
-            <img src="img/jekyll-dark.png" alt="" class="img-responsive">
+            <img src="{{ "/assets/img/jekyll-dark.png" | relative_url }}" alt="Jekyll logo" class="img-responsive">
         </div>
     </div>
     <hr>


### PR DESCRIPTION
Resolution for issue #37 
- Moved `404.html`, `allpages.html`, `search.json` into the `/assets` folder and confirmed that they are now being exported to the _site build.
- Split the `main.scss` up where `main.scss` contains only the imports, while `_sass/_jekyll-doc-theme.scss` contain all the them specific styles.  