### PR TITLE
Removing block display property to keep elements from overlapping and…

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -75,7 +75,6 @@ body {
   }
 }
 *[id]:before {
-  display: block;
   content: " ";
   margin-top: -75px;
   height: 75px;


### PR DESCRIPTION
… hiding each other.

Recent changes seem to have caused some elements, especially those that are dynamically added later, to overlap and cause elements under them from being "clickable". With this update, I've checked most of the pages in the code base locally and deployed on gh-pages which seem to behave properly on both desktop and mobile, but I am certainly not a CSS expert and would like someone else to verify this change does not break something/have unexpected consequences.